### PR TITLE
no longer keep track of keyboard state on a per element basis

### DIFF
--- a/ui/control/keyboard_navigation.lua
+++ b/ui/control/keyboard_navigation.lua
@@ -158,6 +158,24 @@ local default_cell
 ---There only needs to be one since the keyboard can only interact with one thing at a time.
 ---@type keyboard_action?
 local last_action
+---The whether the last keyboard action is a repeated one
+---There only needs to be one since the keyboard can only interact with one thing at a time.
+local last_is_repeat
+
+---The key name that is currently being held down. Only the latest pressed key is considered "held".
+---@type string?
+local holding_key
+
+---Converts love2d key names to keyboard actions
+local key_to_action = {
+    ["return"] = kba.activate,
+    ["space"] = kba.activate,
+    ["escape"] = kba.activate,
+    ["right"] = kba.right,
+    ["left"] = kba.left,
+    ["down"] = kba.down,
+    ["up"] = kba.up,
+}
 
 ---Resets keyboard navigation to its initial state, leaving no cell selected.
 function keyboard_navigation.deactivate()
@@ -179,7 +197,6 @@ function keyboard_navigation.make_cell(mode)
         --erase old fields
         cell.x = nil
         cell.y = nil
-        cell.state = nil
     else
         cell_list[cell_index] = {}
     end
@@ -195,17 +212,7 @@ function keyboard_navigation.make_cell(mode)
     return cell_index
 end
 
----You can either use inject on a state table and later read from the kb fields,
----or use is_selected and get_action to get immedtate values from the navigation.
----You should probably use inject almost always for stateful elements,
----and is_selected and get_action for stateless elements.
-
----Associate the last created cell or a specified cell with a state table so keyboard input fields can be updated.
----@param state table
----@param cell_id? integer
-function keyboard_navigation.inject(state, cell_id)
-    cell_list[cell_id or cell_index].state = state
-end
+---You can use is_selected and get_action to get immedtate values from the navigation.
 
 ---Returns true if the last created cell or specified cell is selected
 ---@param cell_id? integer
@@ -220,6 +227,26 @@ end
 function keyboard_navigation.get_action(cell_id)
     if keyboard_navigation.is_selected(cell_id) then
         return last_action
+    end
+    return nil
+end
+
+---Returns the repeat state of the action on the last created cell
+---@param cell_id? integer
+---@return boolean?
+function keyboard_navigation.is_repeat(cell_id)
+    if keyboard_navigation.is_selected(cell_id) then
+        return last_is_repeat
+    end
+    return nil
+end
+
+---Returns the holding action of the last created cell
+---@param cell_id? integer
+---@return keyboard_action?
+function keyboard_navigation.get_holding(cell_id)
+    if keyboard_navigation.is_selected(cell_id) then
+        return key_to_action[holding_key]
     end
     return nil
 end
@@ -459,21 +486,6 @@ local function navigate_grid(action)
     return nil
 end
 
----The key name that is currently being held down. Only the latest pressed key is considered "held".
----@type string?
-local holding_key
-
----Converts love2d key names to keyboard actions
-local key_to_action = {
-    ["return"] = kba.activate,
-    ["space"] = kba.activate,
-    ["escape"] = kba.activate,
-    ["right"] = kba.right,
-    ["left"] = kba.left,
-    ["down"] = kba.down,
-    ["up"] = kba.up,
-}
-
 ---Iterates through keyboard events and returns an action and whether it was a from a repeated keyboard input.
 ---Also updates the `holding_key` variable.
 ---@return keyboard_action? action Keyboard action. Nil if there was none.
@@ -552,24 +564,8 @@ function keyboard_navigation.evaluate()
 
     local action, is_repeat = iterate_events()
 
-    for i = 1, cell_index do
-        local state = cell_list[i].state
-        if state then
-            if i == selected_cell then
-                state.kb_selected = true
-                state.kb_action = action
-                state.kb_is_repeat = is_repeat
-                state.kb_holding = key_to_action[holding_key]
-            else
-                state.kb_selected = false
-                state.kb_action = nil
-                state.kb_is_repeat = false
-                state.kb_holding = nil
-            end
-        end
-    end
-
     last_action = action
+    last_is_repeat = is_repeat
 
     -- reset everything
     erase_grid()

--- a/ui/element/button.lua
+++ b/ui/element/button.lua
@@ -4,6 +4,7 @@ local clickbox = require("ui.sensor.clickbox")
 local primitive = require("ui.primitive")
 local selection_outline = require("ui.decorator.selection_outline")
 local kba = require("ui.control.keyboard_action")
+local kb_nav = require("ui.control.keyboard_navigation")
 
 
 ---Button element with text. Never reshapes the cursor.
@@ -16,7 +17,7 @@ return function(state, text, font_size)
 
     -- draw background and outline
     local button_color
-    if state.holding or state.kb_holding == kba.activate then
+    if state.holding or kb_nav.get_holding() == kba.activate then
         button_color = theme.widget_background_highlight
     elseif state.hovering then
         button_color = theme.widget_background_brighter
@@ -25,7 +26,7 @@ return function(state, text, font_size)
     end
     primitive.rectangle(button_color)
     primitive.rectangle_outline(
-        (state.hovering or state.kb_selected) and theme.widget_outline_highlight or theme.widget_outline
+        (state.hovering or kb_nav.is_selected()) and theme.widget_outline_highlight or theme.widget_outline
     )
 
     -- draw button internals
@@ -34,7 +35,7 @@ return function(state, text, font_size)
     primitive.label(text, font_size, "left", false)
     cursor.pop()
 
-    if state.kb_selected then
+    if kb_nav.is_selected() then
         selection_outline()
     end
 

--- a/ui/element/checkbox.lua
+++ b/ui/element/checkbox.lua
@@ -5,6 +5,7 @@ local element = require("ui.element")
 local theme = require("ui.theme")
 local effect = require("ui.effect")
 local selection_outline = require("ui.decorator.selection_outline")
+local kb_nav = require("ui.control.keyboard_navigation")
 
 
 ---Checkbox with a intermediate state that can only be accessed by manually setting the position field
@@ -25,13 +26,13 @@ return function(state)
     end
     primitive.rectangle(button_color)
     primitive.rectangle_outline(
-        (state.hovering or state.kb_selected) and theme.widget_outline_highlight or theme.widget_outline
+        (state.hovering or kb_nav.is_selected()) and theme.widget_outline_highlight or theme.widget_outline
     )
 
     primitive.icon("three-dots")
     primitive.icon("three-dots")
 
-    if state.kb_selected then
+    if kb_nav.is_selected() then
         selection_outline()
     end
     cursor.do_auto_reshape()

--- a/ui/element/cycle_button.lua
+++ b/ui/element/cycle_button.lua
@@ -5,6 +5,7 @@ local primitive = require("ui.primitive")
 local selection_outline = require("ui.decorator.selection_outline")
 local mb = require("ui.control.mouse_button")
 local kba = require("ui.control.keyboard_action")
+local kb_nav = require("ui.control.keyboard_navigation")
 
 ---Button element that cycles between text when left or right clicked.
 ---Never reshapes the cursor.
@@ -26,13 +27,14 @@ return function(state, font_size, ...)
         state.initialized = true
     end
 
-    if not state.kb_is_repeat then
-        if state.clicked == mb.left or state.kb_action == kba.right or state.kb_action == kba.activate then
+    if not kb_nav.is_repeat() then
+        local kb_action = kb_nav.get_action()
+        if state.clicked == mb.left or kb_action == kba.right or kb_action == kba.activate then
             state.position = state.position + 1
             if state.position > positions then
                 state.position = 1
             end
-        elseif state.clicked == mb.right or state.kb_action == kba.left then
+        elseif state.clicked == mb.right or kb_action == kba.left then
             state.position = state.position - 1
             if state.position < 1 then
                 state.position = positions
@@ -44,7 +46,7 @@ return function(state, font_size, ...)
 
     -- draw background and outline
     local button_color
-    if state.holding or state.kb_holding then
+    if state.holding or kb_nav.get_holding() then
         button_color = theme.widget_background_highlight
     elseif state.hovering then
         button_color = theme.widget_background_brighter
@@ -53,7 +55,7 @@ return function(state, font_size, ...)
     end
     primitive.rectangle(button_color)
     primitive.rectangle_outline(
-        (state.hovering or state.kb_selected) and theme.widget_outline_highlight or theme.widget_outline
+        (state.hovering or kb_nav.is_selected()) and theme.widget_outline_highlight or theme.widget_outline
     )
 
     -- draw button internals
@@ -62,7 +64,7 @@ return function(state, font_size, ...)
     primitive.label(select(state.position, ...), font_size, "left", false)
     cursor.pop()
 
-    if state.kb_selected then
+    if kb_nav.is_selected() then
         selection_outline()
     end
 

--- a/ui/element/icon_button.lua
+++ b/ui/element/icon_button.lua
@@ -4,6 +4,7 @@ local clickbox = require("ui.sensor.clickbox")
 local primitive = require("ui.primitive")
 local selection_outline = require("ui.decorator.selection_outline")
 local kba = require("ui.control.keyboard_action")
+local kb_nav = require("ui.control.keyboard_navigation")
 
 ---An icon that can be clicked.
 ---Will reshape the cursor
@@ -17,7 +18,7 @@ return function(state, size, icon_name)
     local button_color
     if state.holding then
         button_color = theme.widget_background_highlight
-    elseif state.hovering or state.kb_holding == kba.activate then
+    elseif state.hovering or kb_nav.get_holding() == kba.activate then
         button_color = theme.accent_color
     else
         button_color = theme.white
@@ -27,7 +28,7 @@ return function(state, size, icon_name)
     primitive.icon(icon_name, size, button_color)
     clickbox(state)
 
-    if state.kb_selected then
+    if kb_nav.is_selected() then
         selection_outline()
     end
 

--- a/ui/element/icon_cycle_button.lua
+++ b/ui/element/icon_cycle_button.lua
@@ -5,6 +5,7 @@ local primitive = require("ui.primitive")
 local selection_outline = require("ui.decorator.selection_outline")
 local mb = require("ui.control.mouse_button")
 local kba = require("ui.control.keyboard_action")
+local kb_nav = require("ui.control.keyboard_navigation")
 
 ---An icon that cycles between other icons when left or right clicked.
 ---Will reshape the cursor.
@@ -25,13 +26,14 @@ return function(state, size, ...)
         state.initialized = true
     end
 
-    if not state.kb_is_repeat then
-        if state.clicked == mb.left or state.kb_action == kba.right or state.kb_action == kba.activate then
+    if not kb_nav.is_repeat() then
+        local kb_action = kb_nav.get_action()
+        if state.clicked == mb.left or kb_action == kba.right or kb_action == kba.activate then
             state.position = state.position + 1
             if state.position > positions then
                 state.position = 1
             end
-        elseif state.clicked == mb.right or state.kb_action == kba.left then
+        elseif state.clicked == mb.right or kb_action == kba.left then
             state.position = state.position - 1
             if state.position < 1 then
                 state.position = positions
@@ -44,7 +46,7 @@ return function(state, size, ...)
     local button_color
     if state.holding then
         button_color = theme.widget_background_highlight
-    elseif state.hovering or state.kb_holding == kba.activate then
+    elseif state.hovering or kb_nav.get_holding() == kba.activate then
         button_color = theme.accent_color
     else
         button_color = theme.white
@@ -54,7 +56,7 @@ return function(state, size, ...)
     primitive.icon(select(state.position, ...), size, button_color)
     clickbox(state)
 
-    if state.kb_selected then
+    if kb_nav.is_selected() then
         selection_outline()
     end
 

--- a/ui/element/numeric_input.lua
+++ b/ui/element/numeric_input.lua
@@ -10,6 +10,7 @@ local text = require("ui.text")
 local mouse = require("ui.control.mouse")
 local extmath = require("ui.extmath")
 local kba = require("ui.control.keyboard_action")
+local kb_nav = require("ui.control.keyboard_navigation")
 local selection_outline = require("ui.decorator.selection_outline")
 
 ---Combination number slider and entry with increment buttons.
@@ -37,7 +38,7 @@ return function(state, min, max, step, format)
     local full_width = math.max(element.numeric_input_min_width, cursor.width)
     cursor.place(full_width, element.numeric_input_height)
 
-    local hovering = state.hovering or state.kb_selected
+    local hovering = state.hovering or kb_nav.is_selected()
     local center_width = cursor.width - element.numeric_input_lr_button_width * 2
 
     cursor.auto_reshape = false
@@ -107,11 +108,13 @@ return function(state, min, max, step, format)
         cursor.width = element.numeric_input_lr_button_width
         cursor.change_anchor(0.5)
 
+        local kb_action = kb_nav.get_action()
+        local kb_holding = kb_nav.get_holding()
         if not dragging then
-            if clickbox(state.numeric_input_left) or state.kb_action == kba.left then
+            if clickbox(state.numeric_input_left) or kb_action == kba.left then
                 state.value = state.value - step
             end
-            if state.numeric_input_left.holding or state.kb_holding == kba.left then
+            if state.numeric_input_left.holding or kb_holding == kba.left then
                 primitive.rectangle(theme.widget_background_highlight)
             elseif state.numeric_input_left.hovering then
                 primitive.rectangle(theme.widget_background_brighter)
@@ -126,10 +129,10 @@ return function(state, min, max, step, format)
         cursor.change_anchor(0.5)
 
         if not dragging then
-            if clickbox(state.numeric_input_right) or state.kb_action == kba.right then
+            if clickbox(state.numeric_input_right) or kb_action == kba.right then
                 state.value = state.value + step
             end
-            if state.numeric_input_right.holding or state.kb_holding == kba.right then
+            if state.numeric_input_right.holding or kb_holding == kba.right then
                 primitive.rectangle(theme.widget_background_highlight)
             elseif state.numeric_input_right.hovering then
                 primitive.rectangle(theme.widget_background_brighter)
@@ -145,7 +148,7 @@ return function(state, min, max, step, format)
     primitive.rectangle_outline((hovering or dragging) and theme.widget_outline_highlight or theme.widget_outline)
     hoverbox(state, "pass")
 
-    if state.kb_selected then
+    if kb_nav.is_selected() then
         selection_outline()
     end
 

--- a/ui/element/slider.lua
+++ b/ui/element/slider.lua
@@ -7,6 +7,7 @@ local element = require("ui.element")
 local mouse = require("ui.control.mouse")
 local extmath = require("ui.extmath")
 local kba = require("ui.control.keyboard_action")
+local kb_nav = require("ui.control.keyboard_navigation")
 local selection_outline = require("ui.decorator.selection_outline")
 
 local actuator_radius = element.slider_height / 2
@@ -54,10 +55,11 @@ return function(state, min, max, positions, show_positions)
     local dragging = dragbox(state)
     local hovering = state.hovering
 
-    if state.kb_action then
-        if state.kb_action == kba.left then
+    local kb_action = kb_nav.get_action()
+    if kb_action then
+        if kb_action == kba.left then
             state.position = state.position - 1
-        elseif state.kb_action == kba.right then
+        elseif kb_action == kba.right then
             state.position = state.position + 1
         end
         state.position = extmath.clamp(state.position, 0, divisions)
@@ -117,7 +119,7 @@ return function(state, min, max, positions, show_positions)
 
     cursor.pop() -- (2)
 
-    if state.kb_selected then
+    if kb_nav.is_selected() then
         selection_outline()
     end
 

--- a/ui/element/switch.lua
+++ b/ui/element/switch.lua
@@ -6,6 +6,7 @@ local element = require("ui.element")
 local mask = require("ui.mask")
 local effect = require("ui.effect")
 local reserve = require("ui.reserve")
+local kb_nav = require("ui.control.keyboard_navigation")
 local kba = require("ui.control.keyboard_action")
 local mb = require("ui.control.mouse_button")
 local selection_outline = require("ui.decorator.selection_outline")
@@ -42,7 +43,7 @@ return function(state, ...)
     local sel_hl_res = reserve.allocate(1)
 
     -- selection buttons
-    local hovering = state.kb_selected
+    local hovering = kb_nav.is_selected()
     local section_width = cursor.h_split(positions)
     for i = 1, positions do
         cursor.pop()
@@ -74,8 +75,9 @@ return function(state, ...)
     end
 
     -- keyboard navigation
-    if not state.kb_is_repeat then
-        if state.kb_action == kba.left then
+    if not kb_nav.is_repeat() then
+        local kb_action = kb_nav.get_action()
+        if kb_action == kba.left then
             if state.position == 1 then
                 state.position = positions
                 state._switch_selection_highlight_speed = (positions - 1) * selection_highlight_speed
@@ -83,7 +85,7 @@ return function(state, ...)
                 state.position = state.position - 1
                 state._switch_selection_highlight_speed = selection_highlight_speed
             end
-        elseif state.kb_action == kba.activate or state.kb_action == kba.right then
+        elseif kb_action == kba.activate or kb_action == kba.right then
             if state.position == positions then
                 state.position = 1
                 state._switch_selection_highlight_speed = (positions - 1) * selection_highlight_speed
@@ -109,7 +111,7 @@ return function(state, ...)
 
     cursor.pop() -- (2)
     primitive.rectangle_outline(hovering and theme.accent_color or theme.widget_outline)
-    if state.kb_selected then
+    if kb_nav.is_selected() then
         selection_outline()
     end
     cursor.do_auto_reshape() -- (1)

--- a/ui/element/toggle.lua
+++ b/ui/element/toggle.lua
@@ -4,6 +4,7 @@ local primitive = require("ui.primitive")
 local element = require("ui.element")
 local theme = require("ui.theme")
 local mb = require("ui.control.mouse_button")
+local kb_nav = require("ui.control.keyboard_navigation")
 
 local effect = require("ui.effect")
 local selection_outline = require("ui.decorator.selection_outline")
@@ -18,7 +19,7 @@ return function(state)
     if -- toggle state on
         state.clicked == mb.left -- left click
         or state.clicked == mb.right -- right click
-        or (not state.kb_is_repeat and state.kb_action) -- any non-repeated keyboard action
+        or (not kb_nav.is_repeat() and kb_nav.get_action()) -- any non-repeated keyboard action
     then
         state.on = not state.on
     end
@@ -51,7 +52,7 @@ return function(state)
         cursor.pop()
 
         -- keyboard selection outline
-        if state.kb_selected then
+        if kb_nav.is_selected() then
             selection_outline()
         end
     end

--- a/ui/element/toggle_hex.lua
+++ b/ui/element/toggle_hex.lua
@@ -9,6 +9,7 @@ local draw_queue = require("ui.draw_queue")
 local mb = require("ui.control.mouse_button")
 local effect = require("ui.effect")
 local selection_outline = require("ui.decorator.selection_outline")
+local kb_nav = require("ui.control.keyboard_navigation")
 
 local indiameter = element.toggle_height
 local diameter = extmath.from_inradius(indiameter, 6)
@@ -50,7 +51,7 @@ return function(state)
     if -- toggle state on
         state.clicked == mb.left -- left click
         or state.clicked == mb.right -- right click
-        or (not state.kb_is_repeat and state.kb_action) -- any non-repeated keyboard action
+        or (not kb_nav.is_repeat() and kb_nav.get_action()) -- any non-repeated keyboard action
     then
         state.on = not state.on
     end
@@ -84,7 +85,7 @@ return function(state)
         cursor.pop()
 
         -- keyboard selection outline
-        if state.kb_selected then
+        if kb_nav.is_selected() then
             selection_outline()
         end
     end

--- a/ui/id_table.lua
+++ b/ui/id_table.lua
@@ -21,12 +21,6 @@
     on boolean --- contains whatever boolean data the element may be representing
     text string --- contains whatever string data the element may be representing
 
-    * Keyboard Input Injection
-    kb_selected boolean --- True when the keyboard navigation has selected the cell associated with this state
-    kb_action keyboard_action --- The keyboard action sent to this element.
-    kb_is_repeat boolean --- True when the sent keyboard action is from a repeated input.
-    kb_holding keyboard_action --- The keyboard action that is being held while this element is selected.
-
     * Other fields
     initialized boolean --- may be used to keep track of first time initialization
 ]]

--- a/ui/menu/example.lua
+++ b/ui/menu/example.lua
@@ -37,7 +37,6 @@ return function()
 
     kb_nav.make_cell()
     kb_nav.grid_cell(1, 1)
-    kb_nav.inject(id.numeric)
     numeric_input(id.numeric, -100, 100, 5, "X = %.2f")
     if id.numeric.clicked then
         print("numeric_input clicked")
@@ -47,7 +46,6 @@ return function()
     -- Slider
     kb_nav.make_cell()
     kb_nav.grid_cell(1, 2)
-    kb_nav.inject(id.slider)
     slider(id.slider, 0, 100, 101)
     cursor.shift_down(10)
     primitive.label(string.format("%d%%", id.slider.value), 16, "left", false)
@@ -57,7 +55,6 @@ return function()
     cursor.width = 150
     kb_nav.make_cell()
     kb_nav.grid_cell(1, 3)
-    kb_nav.inject(id.slider_coarse)
     slider(id.slider_coarse, 0, 10, 11, true)
     cursor.shift_down(10)
     primitive.label(string.format("%d/10", id.slider_coarse.value), 16, "left", false)
@@ -67,45 +64,38 @@ return function()
     cursor.width = 150
     kb_nav.make_cell()
     kb_nav.grid_cell(1, 4)
-    kb_nav.inject(id.switch)
     switch(id.switch, "a", "b", "c")
     cursor.shift_down(10)
 
     kb_nav.make_cell()
     kb_nav.grid_cell(1, 5)
-    kb_nav.inject(id.button)
     button(id.button, "button", 16)
     cursor.shift_down(10)
 
     kb_nav.make_cell()
     kb_nav.grid_cell(1, 6)
-    kb_nav.inject(id.cycle_button)
     cycle_button(id.cycle_button, 16, "square", "triangle", "hexagon")
     cursor.shift_down(10)
 
     -- Toggles
     kb_nav.make_cell()
     kb_nav.grid_cell(1, 7)
-    kb_nav.inject(id.toggle)
 
     toggle(id.toggle)
     cursor.shift_down(10)
 
     kb_nav.make_cell()
     kb_nav.grid_cell(1, 8)
-    kb_nav.inject(id.toggle_hex)
     toggle_hex(id.toggle_hex)
     cursor.shift_down(10)
 
     kb_nav.make_cell()
     kb_nav.grid_cell(1, 9)
-    kb_nav.inject(id.icon_button)
     icon_button(id.icon_button, 16, "triangle")
     cursor.shift_down(10)
 
     kb_nav.make_cell()
     kb_nav.grid_cell(1, 10)
-    kb_nav.inject(id.icon_cycle_button)
     icon_cycle_button(id.icon_cycle_button, 16, "square", "dash-square", "check-square")
     cursor.shift_down(10)
 end


### PR DESCRIPTION
Puts all keyboard state into the keyboard navigation module instead of setting it in element specific tables.