### PR TITLE
View request outside draw queue

### DIFF
--- a/ui/area/element/scroll.lua
+++ b/ui/area/element/scroll.lua
@@ -13,8 +13,6 @@ local stack_data = require("ui.stack_manager.stack_data")
 local aeb_stack = stack_data.aeb_stack
 local selection_outline_add_to_queue = require("ui.decorator.element.selection_outline").add_to_queue
 local draw_queue = require("ui.draw_queue")
-local draw_data_add_draw_operation = require("ui.draw_queue.draw_data").add_draw_operation
-local view_request_export_picture_frame = require("ui.draw_queue.draw_operation").view_request_export_picture_frame
 
 local scroll = {}
 
@@ -198,15 +196,7 @@ function scroll.finish(padding)
 
     -- If flagged by a view request, export picture frame data
     if flagged_for_view_request then
-        draw_data_add_draw_operation(
-            view_request_export_picture_frame,
-            state,
-            dist_limit_left,
-            dist_limit_top,
-            dist_limit_right,
-            dist_limit_bottom,
-            picture_frame_id
-        )
+        view_request.add_picture_frame_data(state, dist_limit_left, dist_limit_top, dist_limit_right, dist_limit_bottom, picture_frame_id)
     end
 
     interacting_with_mouse = mnav.is_hovering(scroll_region)

--- a/ui/area/view_request.lua
+++ b/ui/area/view_request.lua
@@ -26,7 +26,7 @@ local view_request = {
 
 local pf_data = {}
 local pf_data_index = 0
-local pf_data_size = 11
+local pf_data_size = 8
 
 local just_initiated = false
 local view_location_placement_id
@@ -79,23 +79,17 @@ function view_request.add_picture_frame_data(
     dist_limit_top,
     dist_limit_right,
     dist_limit_bottom,
-    pf_left,
-    pf_top,
-    pf_right,
-    pf_bottom
+    pf_placement_id
 )
     pf_data_index = pf_data_index + pf_data_size
 
-    -- there are two speed values at -9 and -10 here but they are purposely preserved between frames
-    pf_data[pf_data_index - 8] = state
-    pf_data[pf_data_index - 7] = dist_limit_left
-    pf_data[pf_data_index - 6] = dist_limit_top
-    pf_data[pf_data_index - 5] = dist_limit_right
-    pf_data[pf_data_index - 4] = dist_limit_bottom
-    pf_data[pf_data_index - 3] = pf_left
-    pf_data[pf_data_index - 2] = pf_top
-    pf_data[pf_data_index - 1] = pf_right
-    pf_data[pf_data_index] = pf_bottom
+    -- there are two speed values at -6 and -7 here but they are purposely preserved between frames
+    pf_data[pf_data_index - 5] = state
+    pf_data[pf_data_index - 4] = dist_limit_left
+    pf_data[pf_data_index - 3] = dist_limit_top
+    pf_data[pf_data_index - 2] = dist_limit_right
+    pf_data[pf_data_index - 1] = dist_limit_bottom
+    pf_data[pf_data_index] = pf_placement_id
 end
 
 local function calculate_speed_heuristic(v_left, v_top, v_right, v_bottom)
@@ -105,15 +99,12 @@ local function calculate_speed_heuristic(v_left, v_top, v_right, v_bottom)
     local move_distance, speed
 
     for i = pf_data_size, pf_data_index, pf_data_size do
-        state = pf_data[i - 8]
-        dist_limit_left = pf_data[i - 7]
-        dist_limit_top = pf_data[i - 6]
-        dist_limit_right = pf_data[i - 5]
-        dist_limit_bottom = pf_data[i - 4]
-        pf_left = pf_data[i - 3]
-        pf_top = pf_data[i - 2]
-        pf_right = pf_data[i - 1]
-        pf_bottom = pf_data[i]
+        state = pf_data[i - 5]
+        dist_limit_left = pf_data[i - 4]
+        dist_limit_top = pf_data[i - 3]
+        dist_limit_right = pf_data[i - 2]
+        dist_limit_bottom = pf_data[i - 1]
+        pf_left, pf_top, pf_right, pf_bottom = draw_queue.get_placement(pf_data[i])
 
         -- x movement
         move_distance = 0
@@ -127,7 +118,7 @@ local function calculate_speed_heuristic(v_left, v_top, v_right, v_bottom)
             move_distance = math.max(pf_right - v_right, dist_limit_right - state.scroll_dist_x)
             speed = move_distance * base_speed
         end
-        pf_data[i - 10] = math.abs(speed)
+        pf_data[i - 7] = math.abs(speed)
         v_left = v_left + move_distance -- move the requested area for the next iteration
         v_right = v_right + move_distance
 
@@ -143,7 +134,7 @@ local function calculate_speed_heuristic(v_left, v_top, v_right, v_bottom)
             move_distance = math.max(pf_bottom - v_bottom, dist_limit_bottom - state.scroll_dist_y)
             speed = move_distance * base_speed
         end
-        pf_data[i - 9] = math.abs(speed)
+        pf_data[i - 6] = math.abs(speed)
         v_top = v_top + move_distance -- move the requested area for the next iteration
         v_bottom = v_bottom + move_distance
     end
@@ -178,13 +169,10 @@ function view_request.evaluate()
     local x_speed, y_speed
 
     for i = pf_data_size, pf_data_index, pf_data_size do
-        x_speed = pf_data[i - 10]
-        y_speed = pf_data[i - 9]
-        state = pf_data[i - 8]
-        pf_left = pf_data[i - 3]
-        pf_top = pf_data[i - 2]
-        pf_right = pf_data[i - 1]
-        pf_bottom = pf_data[i]
+        x_speed = pf_data[i - 7]
+        y_speed = pf_data[i - 6]
+        state = pf_data[i - 5]
+        pf_left, pf_top, pf_right, pf_bottom = draw_queue.get_placement(pf_data[i])
 
         -- x movement
         target = nil

--- a/ui/draw_queue/draw.lua
+++ b/ui/draw_queue/draw.lua
@@ -6,7 +6,6 @@ local draw_data = require("ui.draw_queue.draw_data")
 local op_ids = require("ui.draw_queue.draw_operation")
 local settings = require("ui.settings")
 local theme = require("ui.theme")
-local view_request = require("ui.area.view_request")
 local draw_queue = require("ui.draw_queue")
 local bit = require("bit")
 local band = bit.band
@@ -201,17 +200,6 @@ return function()
                 -- luacov: enable
             elseif id == op_ids.set_shader then
                 love.graphics.setShader(item[2])
-            elseif id == op_ids.view_request_export_picture_frame then
-                view_request.add_picture_frame_data(
-                    item[2],
-                    -- distance limits
-                    item[3],
-                    item[4],
-                    item[5],
-                    item[6],
-                    -- picture frame area
-                    draw_data.get_placement(item[7])
-                )
 
             -- * overlay
             elseif band(id, 0xF00) == 0x300 then

--- a/ui/draw_queue/draw_operation.lua
+++ b/ui/draw_queue/draw_operation.lua
@@ -22,7 +22,6 @@ local draw_operation = {
     pop_scissor = 0x202,
     mouse_sensor = 0x203, -- behaves like a normal draw operation
     set_shader = 0x1204, -- cannot be reserved
-    view_request_export_picture_frame = 0x1206, -- cannot be reserved
 
     -- overlay draw operations
     -- these are identical to the draw operations except that they get put at the end of the draw_list


### PR DESCRIPTION
This change removes a needless draw operation by storing the placement id and getting the changed values from bake_translations later rather than relying on the draw queue to call get_placement later.