### PR TITLE
Adjust example and tests for api changes

### DIFF
--- a/examples/menu/example.lua
+++ b/examples/menu/example.lua
@@ -58,7 +58,7 @@ return function()
     knav.set_wrapping(wmode.redirect, wmode.vertical)
     knav.set_page_length(2)
 
-    cursor.auto_reshape = true
+    cursor.auto_reshape = "both"
     cursor.x = 60
     cursor.y = 10
     cursor.width = 150

--- a/examples/menu/example.lua
+++ b/examples/menu/example.lua
@@ -188,7 +188,7 @@ Rerum ducimus tenetur fugit.
         end
 
         typing.make_text_entry(id.text_entry, text_entry_sensor, text_entry_cell)
-        typing.draw_text_entry(24, "Search")
+        typing.draw_text_entry(id.text_entry, 24, "Search")
         cursor.shift_down(10)
     end
 
@@ -203,7 +203,7 @@ Rerum ducimus tenetur fugit.
         end
 
         typing.make_text_entry(id.text_entry2, text_entry_sensor2, text_entry_cell2, true)
-        typing.draw_text_entry(36, "Search2")
+        typing.draw_text_entry(id.text_entry2, 36, "Search2")
         cursor.shift_down(10)
     end
 

--- a/examples/menu/example.lua
+++ b/examples/menu/example.lua
@@ -171,7 +171,7 @@ Rerum ducimus tenetur fugit.
 
     knav.make_cell()
     knav.grid_cell(1, 12)
-    checkbox(id.checkbox)
+    checkbox(id.checkbox, 16)
     cursor.shift_down(10)
 
     cursor.width = 200

--- a/examples/menu/scroll_example.lua
+++ b/examples/menu/scroll_example.lua
@@ -21,7 +21,7 @@ return function()
     draw_by_cursor.rectangle({ 0, 0, 0, 0.8 })
     knav.set_wrapping(wmode.tab, wmode.vertical)
 
-    cursor.auto_reshape = true
+    cursor.auto_reshape = "both"
     cursor.x = 200
     cursor.y = 50
     cursor.width = 200
@@ -114,7 +114,7 @@ return function()
 
         local grid_i = 11
         do
-            cursor.auto_reshape = false
+            cursor.auto_reshape = "both"
             cursor.width = 170
             cursor.height = 20
 

--- a/examples/menu/scroll_example.lua
+++ b/examples/menu/scroll_example.lua
@@ -60,8 +60,8 @@ return function()
                 end
             end
         end
-        background.finish(10, theme.blue)
-        local at_left, at_top, at_right, at_bottom = scroll.finish(0)
+        background.finish(theme.blue, 10, 10, 10, 10)
+        local at_left, at_top, at_right, at_bottom = scroll.finish(0, 0, 0, 0, 0)
 
         knav.fill_grid(knav.op_cell.tab, 6, 1, 1, 5)
         cursor.push()
@@ -91,8 +91,8 @@ return function()
                 end
             end
         end
-        background.finish(10, theme.blue)
-        scroll.finish(0)
+        background.finish(theme.blue, 10, 10, 10, 10)
+        scroll.finish(0, 0, 0, 0, 0)
 
         cursor.pop()
         cursor.shift_down(10)
@@ -197,6 +197,6 @@ return function()
             layers.pop()
         end
     end
-    background.finish(10, theme.red)
-    scroll.finish(0)
+    background.finish(theme.red, 10, 10, 10, 10)
+    scroll.finish(0, 0, 0, 0, 0)
 end

--- a/examples/tests/unit/cursor/area.lua
+++ b/examples/tests/unit/cursor/area.lua
@@ -13,7 +13,8 @@ function T.set_up()
     cursor.x, cursor.y = 0, 0
     cursor.width, cursor.height = 10, 10
     cursor.anchor_x, cursor.anchor_y = 0, 0
-    cursor.auto_reshape = false
+    cursor.auto_area_expansion = "placement"
+    cursor.auto_reshape = "no"
 end
 
 function T.tear_down()
@@ -176,7 +177,7 @@ function T.test_no_area_expansion()
 
     cursor.x = 100
     cursor.y = 100
-    cursor.place(nil, nil, true)
+    cursor.place(nil, nil, "no")
 
     cursor.put_area()
 

--- a/examples/tests/unit/cursor/area.lua
+++ b/examples/tests/unit/cursor/area.lua
@@ -41,7 +41,7 @@ function T.test_area()
     -- inner areas will update outer areas when finish_area is called
     cursor.finish_area()
 
-    l, t, r, b = cursor.ltrb()
+    l, t, r, b = cursor.get_edges()
     unittest.assert(l == 100)
     unittest.assert(t == 100)
     unittest.assert(r == 210)
@@ -49,7 +49,7 @@ function T.test_area()
 
     cursor.finish_area()
 
-    l, t, r, b = cursor.ltrb()
+    l, t, r, b = cursor.get_edges()
     unittest.assert(l == 0)
     unittest.assert(t == 0)
     unittest.assert(r == 210)
@@ -73,7 +73,7 @@ function T.test_empty_area()
     cursor.y = 200
     cursor.finish_area()
 
-    l, t, r, b = cursor.ltrb()
+    l, t, r, b = cursor.get_edges()
     unittest.assert(l == 200)
     unittest.assert(t == 200)
     unittest.assert(r == 210)
@@ -81,7 +81,7 @@ function T.test_empty_area()
 
     cursor.finish_area()
 
-    l, t, r, b = cursor.ltrb()
+    l, t, r, b = cursor.get_edges()
     unittest.assert(l == 0)
     unittest.assert(t == 0)
     unittest.assert(r == 110)
@@ -112,7 +112,7 @@ function T.test_area_rollback()
     stack_manager.pop_record()
 
     -- cursor remains unaffected
-    l, t, r, b = cursor.ltrb()
+    l, t, r, b = cursor.get_edges()
     unittest.assert(l == 200)
     unittest.assert(t == 200)
     unittest.assert(r == 210)
@@ -121,7 +121,7 @@ function T.test_area_rollback()
     cursor.finish_area()
 
     -- this area doesn't know about the square at (200, 200)
-    l, t, r, b = cursor.ltrb()
+    l, t, r, b = cursor.get_edges()
     unittest.assert(l == 0)
     unittest.assert(t == 0)
     unittest.assert(r == 110)
@@ -145,7 +145,7 @@ function T.test_put_area()
 
     cursor.put_area()
 
-    l, t, r, b = cursor.ltrb()
+    l, t, r, b = cursor.get_edges()
     unittest.assert(l == 0)
     unittest.assert(t == 0)
     unittest.assert(r == 110)
@@ -159,7 +159,7 @@ function T.test_put_empty_area()
 
     cursor.put_area()
 
-    l, t, r, b = cursor.ltrb()
+    l, t, r, b = cursor.get_edges()
     unittest.assert(l == 0)
     unittest.assert(t == 0)
     unittest.assert(r == 10)
@@ -181,7 +181,7 @@ function T.test_no_area_expansion()
 
     cursor.put_area()
 
-    l, t, r, b = cursor.ltrb()
+    l, t, r, b = cursor.get_edges()
     unittest.assert(l == 0)
     unittest.assert(t == 0)
     unittest.assert(r == 10)
@@ -211,14 +211,14 @@ function T.test_no_propogate()
     cursor.y = 300
     cursor.place()
     cursor.finish_area(true)
-    l, t, r, b = cursor.ltrb()
+    l, t, r, b = cursor.get_edges()
     unittest.assert(l == 200)
     unittest.assert(t == 200)
     unittest.assert(r == 310)
     unittest.assert(b == 310)
 
     cursor.finish_area()
-    l, t, r, b = cursor.ltrb()
+    l, t, r, b = cursor.get_edges()
     unittest.assert(l == 0)
     unittest.assert(t == 0)
     unittest.assert(r == 110)

--- a/examples/tests/unit/cursor/cursor.lua
+++ b/examples/tests/unit/cursor/cursor.lua
@@ -215,27 +215,13 @@ function T.test_cursor_stack_drop()
     unittest.assert_error(cursor.pop, "we should be at the bottom of the stack")
 end
 
-function T.test_cursor_swizzling()
-    local a, b, c, d = cursor.ltrb()
+function T.test_get_edges()
+    local a, b, c, d = cursor.get_edges()
 
     unittest.assert(a == cursor.x - cursor.anchor_x * cursor.width)
     unittest.assert(b == cursor.y - cursor.anchor_y * cursor.height)
     unittest.assert(c == cursor.x + (1 - cursor.anchor_x) * cursor.width)
     unittest.assert(d == cursor.y + (1 - cursor.anchor_y) * cursor.height)
-
-    a, b, c, d = cursor.rrtb()
-
-    unittest.assert(a == cursor.x + (1 - cursor.anchor_x) * cursor.width)
-    unittest.assert(b == cursor.x + (1 - cursor.anchor_x) * cursor.width)
-    unittest.assert(c == cursor.y - cursor.anchor_y * cursor.height)
-    unittest.assert(d == cursor.y + (1 - cursor.anchor_y) * cursor.height)
-end
-
-function T.test_invalid_swizzling()
-    -- this has to be wrapped or it causes an actual error
-    unittest.assert_error(function()
-        cursor.g()
-    end)
 end
 
 function T.test_do_auto_reshape()
@@ -435,11 +421,11 @@ function T.test_change_anchor()
     cursor.x, cursor.y = 0, 0
     cursor.width, cursor.height = 10, 10
 
-    l, t, r, b = cursor.ltrb()
+    l, t, r, b = cursor.get_edges()
 
     cursor.change_anchor(1)
 
-    l2, t2, r2, b2 = cursor.ltrb()
+    l2, t2, r2, b2 = cursor.get_edges()
 
     unittest.assert(l == l2)
     unittest.assert(t == t2)
@@ -450,7 +436,7 @@ function T.test_change_anchor()
 
     cursor.change_anchor(0.5, 0.7)
 
-    l2, t2, r2, b2 = cursor.ltrb()
+    l2, t2, r2, b2 = cursor.get_edges()
 
     unittest.assert(l == l2)
     unittest.assert(t == t2)
@@ -462,11 +448,11 @@ end
 
 function T.test_inset_outset()
     local l, t, r, b, l2, t2, r2, b2
-    l, t, r, b = cursor.ltrb()
+    l, t, r, b = cursor.get_edges()
 
     cursor.inset(10)
 
-    l2, t2, r2, b2 = cursor.ltrb()
+    l2, t2, r2, b2 = cursor.get_edges()
     unittest.assert(l + 10 == l2)
     unittest.assert(t + 10 == t2)
     unittest.assert(r - 10 == r2)
@@ -474,7 +460,7 @@ function T.test_inset_outset()
 
     cursor.outset(10)
 
-    l2, t2, r2, b2 = cursor.ltrb()
+    l2, t2, r2, b2 = cursor.get_edges()
     unittest.assert(l == l2)
     unittest.assert(t == t2)
     unittest.assert(r == r2)

--- a/examples/tests/unit/cursor/cursor.lua
+++ b/examples/tests/unit/cursor/cursor.lua
@@ -675,19 +675,19 @@ function T.test_clip_bottom()
     unittest.assert(cursor.anchor_y == 1)
 end
 
-function T.test_full_width()
-    cursor.full_width()
+function T.test_h_fit_screen()
+    -- must reset first for cursor to store screen dimensions
+    cursor.reset()
+    cursor.width = 10
+    cursor.h_fit_screen()
     unittest.assert(cursor.width == screen_width)
 end
 
-function T.test_full_height()
-    cursor.full_height()
-    unittest.assert(cursor.height == screen_height)
-end
-
-function T.test_full_screen()
-    cursor.full_screen()
-    unittest.assert(cursor.width == screen_width)
+function T.test_v_fit_screen()
+    -- must reset first for cursor to store screen dimensions
+    cursor.reset()
+    cursor.height = 10
+    cursor.v_fit_screen()
     unittest.assert(cursor.height == screen_height)
 end
 

--- a/examples/tests/unit/cursor/cursor.lua
+++ b/examples/tests/unit/cursor/cursor.lua
@@ -43,12 +43,14 @@ function T.test_cursor_reset()
     unittest.assert(cursor.anchor_y == 0)
     unittest.assert(cursor.auto_reshape == "both")
 
-    cursor.reset(300, 300)
+    cursor.width = 10
+    cursor.height = 10
+    cursor.reset()
 
     unittest.assert(cursor.x == 0)
     unittest.assert(cursor.y == 0)
-    unittest.assert(cursor.width == 300)
-    unittest.assert(cursor.height == 300)
+    unittest.assert(cursor.width == width)
+    unittest.assert(cursor.height == height)
     unittest.assert(cursor.anchor_x == 0)
     unittest.assert(cursor.anchor_y == 0)
     unittest.assert(cursor.auto_reshape == "both")

--- a/examples/tests/unit/cursor/cursor.lua
+++ b/examples/tests/unit/cursor/cursor.lua
@@ -17,7 +17,7 @@ function T.set_up()
     cursor.x, cursor.y = 0, 0
     cursor.width, cursor.height = 128, 128
     cursor.anchor_x, cursor.anchor_y = 0, 0
-    cursor.auto_reshape = false
+    cursor.auto_reshape = "no"
 
     placement.left = 0
     placement.top = 0
@@ -41,7 +41,7 @@ function T.test_cursor_reset()
     unittest.assert(cursor.height == height)
     unittest.assert(cursor.anchor_x == 0)
     unittest.assert(cursor.anchor_y == 0)
-    unittest.assert(cursor.auto_reshape == true)
+    unittest.assert(cursor.auto_reshape == "both")
 
     cursor.reset(300, 300)
 
@@ -51,28 +51,28 @@ function T.test_cursor_reset()
     unittest.assert(cursor.height == 300)
     unittest.assert(cursor.anchor_x == 0)
     unittest.assert(cursor.anchor_y == 0)
-    unittest.assert(cursor.auto_reshape == true)
+    unittest.assert(cursor.auto_reshape == "both")
 end
 
 function T.test_cursor_stack_push_pop()
     cursor.x, cursor.y = 30, 70
     cursor.width, cursor.height = 50, 80
     cursor.anchor_x, cursor.anchor_y = 0.5, 0.5
-    cursor.auto_reshape = false
+    cursor.auto_reshape = "no"
 
     cursor.push()
     do
         cursor.x, cursor.y = 90, 325
         cursor.width, cursor.height = 410, 35
         cursor.anchor_x, cursor.anchor_y = 1, 1
-        cursor.auto_reshape = true
+        cursor.auto_reshape = "both"
 
         cursor.push()
         do
             cursor.x, cursor.y = 50, 10
             cursor.width, cursor.height = 640, 20
             cursor.anchor_x, cursor.anchor_y = 1, 0
-            cursor.auto_reshape = false
+            cursor.auto_reshape = "no"
         end
         cursor.pop()
 
@@ -82,7 +82,7 @@ function T.test_cursor_stack_push_pop()
         unittest.assert(cursor.height == 35)
         unittest.assert(cursor.anchor_x == 1)
         unittest.assert(cursor.anchor_y == 1)
-        unittest.assert(cursor.auto_reshape == true)
+        unittest.assert(cursor.auto_reshape == "both")
     end
     cursor.pop()
 
@@ -92,7 +92,7 @@ function T.test_cursor_stack_push_pop()
     unittest.assert(cursor.height == 80)
     unittest.assert(cursor.anchor_x == 0.5)
     unittest.assert(cursor.anchor_y == 0.5)
-    unittest.assert(cursor.auto_reshape == false)
+    unittest.assert(cursor.auto_reshape == "no")
 end
 
 function T.test_cursor_stack_underflow()
@@ -103,7 +103,7 @@ function T.test_cursor_stack_rollback()
     cursor.x, cursor.y = 30, 70
     cursor.width, cursor.height = 50, 80
     cursor.anchor_x, cursor.anchor_y = 0.5, 0.5
-    cursor.auto_reshape = false
+    cursor.auto_reshape = "no"
 
     cursor.push()
     do
@@ -113,14 +113,14 @@ function T.test_cursor_stack_rollback()
         cursor.x, cursor.y = 90, 325
         cursor.width, cursor.height = 410, 35
         cursor.anchor_x, cursor.anchor_y = 1, 1
-        cursor.auto_reshape = true
+        cursor.auto_reshape = "both"
 
         cursor.push()
 
         cursor.x, cursor.y = 50, 10
         cursor.width, cursor.height = 640, 20
         cursor.anchor_x, cursor.anchor_y = 1, 0
-        cursor.auto_reshape = false
+        cursor.auto_reshape = "no"
 
         stack_manager.pop_record()
 
@@ -131,7 +131,7 @@ function T.test_cursor_stack_rollback()
         unittest.assert(cursor.height == 20)
         unittest.assert(cursor.anchor_x == 1)
         unittest.assert(cursor.anchor_y == 0)
-        unittest.assert(cursor.auto_reshape == false)
+        unittest.assert(cursor.auto_reshape == "no")
     end
     cursor.pop()
 
@@ -141,7 +141,7 @@ function T.test_cursor_stack_rollback()
     unittest.assert(cursor.height == 80)
     unittest.assert(cursor.anchor_x == 0.5)
     unittest.assert(cursor.anchor_y == 0.5)
-    unittest.assert(cursor.auto_reshape == false)
+    unittest.assert(cursor.auto_reshape == "no")
 end
 
 function T.test_cursor_stack_peek()
@@ -150,14 +150,14 @@ function T.test_cursor_stack_peek()
     cursor.x, cursor.y = 30, 70
     cursor.width, cursor.height = 50, 80
     cursor.anchor_x, cursor.anchor_y = 0.5, 0.5
-    cursor.auto_reshape = false
+    cursor.auto_reshape = "no"
 
     cursor.push()
 
     cursor.x, cursor.y = 50, 10
     cursor.width, cursor.height = 640, 20
     cursor.anchor_x, cursor.anchor_y = 1, 0
-    cursor.auto_reshape = false
+    cursor.auto_reshape = "no"
 
     cursor.peek()
 
@@ -167,12 +167,12 @@ function T.test_cursor_stack_peek()
     unittest.assert(cursor.height == 80)
     unittest.assert(cursor.anchor_x == 0.5)
     unittest.assert(cursor.anchor_y == 0.5)
-    unittest.assert(cursor.auto_reshape == false)
+    unittest.assert(cursor.auto_reshape == "no")
 
     cursor.x, cursor.y = 50, 10
     cursor.width, cursor.height = 640, 20
     cursor.anchor_x, cursor.anchor_y = 1, 0
-    cursor.auto_reshape = false
+    cursor.auto_reshape = "no"
 
     cursor.pop()
 
@@ -182,7 +182,7 @@ function T.test_cursor_stack_peek()
     unittest.assert(cursor.height == 80)
     unittest.assert(cursor.anchor_x == 0.5)
     unittest.assert(cursor.anchor_y == 0.5)
-    unittest.assert(cursor.auto_reshape == false)
+    unittest.assert(cursor.auto_reshape == "no")
 
     unittest.assert_error(cursor.pop, "we should be at the bottom of the stack")
 end
@@ -193,14 +193,14 @@ function T.test_cursor_stack_drop()
     cursor.x, cursor.y = 30, 70
     cursor.width, cursor.height = 50, 80
     cursor.anchor_x, cursor.anchor_y = 0.5, 0.5
-    cursor.auto_reshape = false
+    cursor.auto_reshape = "no"
 
     cursor.push()
 
     cursor.x, cursor.y = 50, 10
     cursor.width, cursor.height = 640, 20
     cursor.anchor_x, cursor.anchor_y = 1, 0
-    cursor.auto_reshape = false
+    cursor.auto_reshape = "no"
 
     cursor.drop()
 
@@ -210,7 +210,7 @@ function T.test_cursor_stack_drop()
     unittest.assert(cursor.height == 20)
     unittest.assert(cursor.anchor_x == 1)
     unittest.assert(cursor.anchor_y == 0)
-    unittest.assert(cursor.auto_reshape == false)
+    unittest.assert(cursor.auto_reshape == "no")
 
     unittest.assert_error(cursor.pop, "we should be at the bottom of the stack")
 end
@@ -243,14 +243,14 @@ function T.test_do_auto_reshape()
         cursor.x, cursor.y = 30, 70
         cursor.width, cursor.height = 50, 80
         cursor.anchor_x, cursor.anchor_y = 0.5, 0.5
-        cursor.auto_reshape = true -- ! do_auto_reshape cares about this value
+        cursor.auto_reshape = "both" -- ! do_auto_reshape cares about this value
 
         cursor.push()
 
         cursor.x, cursor.y = 50, 10
         cursor.width, cursor.height = 640, 20
         cursor.anchor_x, cursor.anchor_y = 1, 0
-        cursor.auto_reshape = false -- ! not this one
+        cursor.auto_reshape = "no" -- ! not this one
 
         cursor.do_auto_reshape()
 
@@ -260,7 +260,7 @@ function T.test_do_auto_reshape()
         unittest.assert(cursor.height == 20)
         unittest.assert(cursor.anchor_x == 0.5)
         unittest.assert(cursor.anchor_y == 0.5)
-        unittest.assert(cursor.auto_reshape == true)
+        unittest.assert(cursor.auto_reshape == "both")
 
         unittest.assert_error(cursor.pop, "we should be at the bottom of the stack")
     end
@@ -269,14 +269,14 @@ function T.test_do_auto_reshape()
         cursor.x, cursor.y = 30, 70
         cursor.width, cursor.height = 50, 80
         cursor.anchor_x, cursor.anchor_y = 0.5, 0.5
-        cursor.auto_reshape = false -- ! do_auto_reshape cares about this value
+        cursor.auto_reshape = "no" -- ! do_auto_reshape cares about this value
 
         cursor.push()
 
         cursor.x, cursor.y = 50, 10
         cursor.width, cursor.height = 640, 20
         cursor.anchor_x, cursor.anchor_y = 1, 0
-        cursor.auto_reshape = true -- ! not this one
+        cursor.auto_reshape = "both" -- ! not this one
 
         cursor.do_auto_reshape()
 
@@ -286,7 +286,7 @@ function T.test_do_auto_reshape()
         unittest.assert(cursor.height == 80)
         unittest.assert(cursor.anchor_x == 0.5)
         unittest.assert(cursor.anchor_y == 0.5)
-        unittest.assert(cursor.auto_reshape == false)
+        unittest.assert(cursor.auto_reshape == "no")
 
         unittest.assert_error(cursor.pop, "we should be at the bottom of the stack")
     end

--- a/examples/tests/unit/text/text_cache.lua
+++ b/examples/tests/unit/text/text_cache.lua
@@ -1,41 +1,31 @@
-local monkeypatch = require("tests.monkeypatch")
-local text_cache = require("ui.text.cache")
+local text_cache_get = require("ui.text.cache")
 local unittest = require("tests.unittest")
+local memoize = require("extlibs.memoize")
 
 local T = {}
 
-local time = 0
-
-function T.set_up_case()
-    love.timer.getTime = monkeypatch.replace(love.timer.getTime, function()
-        return time
-    end)
-end
-
-function T.tear_down_case()
-    love.timer.getTime = monkeypatch.get_original(love.timer.getTime)
-end
-
 function T.test_text_cache()
     local _
-    local o1 = text_cache.get(love.graphics.getFont(), "Hello", math.huge, "left")
-    local o2 = text_cache.get(love.graphics.getFont(), "Hello", math.huge, "left")
+    local o1 = text_cache_get(love.graphics.getFont(), "Hello", math.huge, "left")
+    local o2 = text_cache_get(love.graphics.getFont(), "Hello", math.huge, "left")
     unittest.assert(o1 == o2, "same data should give same object")
     -- get 10 unique objects
     for i = 1, 10 do
-        _ = text_cache.get(love.graphics.getFont(), "Hello" .. i, math.huge, "left")
+        _ = text_cache_get(love.graphics.getFont(), "Hello" .. i, math.huge, "left")
     end
 
-    -- advance time
-    time = 1000
-    -- this should set the usage of earlier text objects to 0
-    _ = text_cache.get(love.graphics.getFont(), "A", math.huge, "left")
-    -- advance time
-    time = 2000
-    -- this should clear the cache of earlier text objects to 0
-    _ = text_cache.get(love.graphics.getFont(), "A", math.huge, "left")
+    local o3 = text_cache_get(love.graphics.getFont(), "Hello1", math.huge, "left")
 
-    o1 = text_cache.get(love.graphics.getFont(), "Hello", math.huge, "left")
+    -- this should set usage to 0
+    memoize.master_sweep()
+
+    local o4 = text_cache_get(love.graphics.getFont(), "Hello1", math.huge, "left")
+    unittest.assert(o3 == o4, "setting usage to 0 should not clear object")
+
+    -- this should clear objects with 0 usage
+    memoize.master_sweep()
+
+    o1 = text_cache_get(love.graphics.getFont(), "Hello", math.huge, "left")
     unittest.assert(o1 ~= o2, "object should not be the same after cache was updated")
 end
 

--- a/ui/cursor.lua
+++ b/ui/cursor.lua
@@ -482,12 +482,12 @@ end
 
 ---Pushes n snapshots to the stack, such that when popping them,
 ---the cursor will move from left to right with padding within the bounding box of the current cursor.
----Cursors take on the shape formed by vertically subdividing the current cursor with padding.
+---Cursors take on the shape formed by horizontally subdividing the current cursor with padding.
 ---@param n integer number of sections to split into
 ---@param padding number? padding between sections
 ---@return integer n number of sections
 ---@return number section_width the width of each resulting section, not including padding
-function cursor.v_subdivide(n, padding)
+function cursor.h_subdivide(n, padding)
     padding = padding or 0
     local section_width = (cursor.width - (n - 1) * padding) / n
     local left_edge = cursor.x - cursor.anchor_x * cursor.width
@@ -534,12 +534,12 @@ end
 
 ---Pushes n snapshots to the stack, such that when popping them,
 ---the cursor will move from top to bottom with padding within the bounding box of the current cursor.
----Cursors take on the shape formed by horizontally subdividing the current cursor with padding.
+---Cursors take on the shape formed by vertically subdividing the current cursor with padding.
 ---@param n integer number of sections to split into
 ---@param padding number? padding between sections
 ---@return integer n number of sections
 ---@return number section_height the height of each resulting section, not including padding
-function cursor.h_subdivide(n, padding)
+function cursor.v_subdivide(n, padding)
     padding = padding or 0
     local section_height = (cursor.height - (n - 1) * padding) / n
     local top_edge = cursor.y - cursor.anchor_y * cursor.height

--- a/ui/element/switch.lua
+++ b/ui/element/switch.lua
@@ -54,7 +54,7 @@ return function(state, custom_sensor, ...)
     local sel_hl_res = draw_queue.allocate_reservation(1)
 
     -- selection buttons
-    local _, section_width = cursor.v_subdivide(positions)
+    local _, section_width = cursor.h_subdivide(positions)
     local left = projected_placement.left
     local right = left + section_width
     local is_inside


### PR DESCRIPTION
The examples and tests still used swizzling, boolean values for area expansion and auto reshape and some other minor things.